### PR TITLE
Feature/dcat enhancement

### DIFF
--- a/connector/openapi-connector/src/main/java/eu/datacellar/connector/OpenAPICoreExtension.java
+++ b/connector/openapi-connector/src/main/java/eu/datacellar/connector/OpenAPICoreExtension.java
@@ -359,15 +359,23 @@ public class OpenAPICoreExtension implements ServiceExtension {
                         ? BodyFixConfig.HTTP_DATA_FIXED_TYPE
                         : HTTP_DATA_TYPE;
 
-                HttpDataAddress dataAddress = HttpDataAddress.Builder.newInstance()
+                boolean hasPathParams = path.contains("{");
+
+                HttpDataAddress.Builder addressBuilder = HttpDataAddress.Builder.newInstance()
                         .name(String.format("data-address-%s", assetId))
                         .baseUrl(baseUrl)
-                        .path(path)
                         .method(method.name())
                         .contentType(contentType)
                         .proxyBody(Boolean.toString(true))
-                        .proxyQueryParams(Boolean.toString(true))
-                        .build();
+                        .proxyQueryParams(Boolean.toString(true));
+
+                if (hasPathParams) {
+                    addressBuilder.property(PathTemplateHttpParamsDecorator.PATH_TEMPLATE_PROP, path);
+                } else {
+                    addressBuilder.path(path);
+                }
+
+                HttpDataAddress dataAddress = addressBuilder.build();
                 if (!HTTP_DATA_TYPE.equals(dataAddressType)) {
                     dataAddress.setType(dataAddressType);
                 }

--- a/connector/openapi-connector/src/main/java/eu/datacellar/connector/OpenAPICoreExtension.java
+++ b/connector/openapi-connector/src/main/java/eu/datacellar/connector/OpenAPICoreExtension.java
@@ -691,6 +691,8 @@ public class OpenAPICoreExtension implements ServiceExtension {
 
         paramsProvider
                 .registerSourceDecorator(new ContractDetailsHttpParamsDecorator(monitor, contractNegotiationStore));
+        paramsProvider
+                .registerSourceDecorator(new PathTemplateHttpParamsDecorator(monitor));
 
         // Check if backend API authentication is configured
         // This will be used to set an API key header in the proxied requests

--- a/connector/openapi-connector/src/main/java/eu/datacellar/connector/PathTemplateHttpParamsDecorator.java
+++ b/connector/openapi-connector/src/main/java/eu/datacellar/connector/PathTemplateHttpParamsDecorator.java
@@ -1,0 +1,101 @@
+package eu.datacellar.connector;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.edc.connector.dataplane.http.spi.HttpDataAddress;
+import org.eclipse.edc.connector.dataplane.http.spi.HttpParamsDecorator;
+import org.eclipse.edc.connector.dataplane.http.spi.HttpRequestParams.Builder;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+
+import okhttp3.HttpUrl;
+
+/**
+ * Resolves OpenAPI path parameter templates stored in the dataAddress.
+ *
+ * For assets with path parameters (e.g. /items/{id}), the path template is
+ * stored as a dataAddress property instead of a literal path. This decorator
+ * substitutes each {variable} with the matching consumer query parameter and
+ * removes those keys from the forwarded query string.
+ */
+public class PathTemplateHttpParamsDecorator implements HttpParamsDecorator {
+
+    public static final String PATH_TEMPLATE_PROP = "pathTemplate";
+    private static final Pattern PATH_PARAM_PATTERN = Pattern.compile("\\{([^}]+)\\}");
+    private static final String PROP_QUERY_PARAMS = "queryParams";
+
+    private final Monitor monitor;
+
+    public PathTemplateHttpParamsDecorator(Monitor monitor) {
+        this.monitor = monitor;
+    }
+
+    @Override
+    public Builder decorate(DataFlowStartMessage request, HttpDataAddress address, Builder builder) {
+        String template = address.getStringProperty(PATH_TEMPLATE_PROP);
+        if (template == null || template.isBlank()) {
+            return builder;
+        }
+
+        monitor.debug("Resolving path template: %s".formatted(template));
+
+        String queryParams = request.getProperties().getOrDefault(PROP_QUERY_PARAMS, null);
+        Map<String, List<String>> queryMap = parseQueryParams(queryParams);
+
+        Matcher matcher = PATH_PARAM_PATTERN.matcher(template);
+        String resolvedPath = template;
+        List<String> substitutedKeys = new ArrayList<>();
+
+        while (matcher.find()) {
+            String varName = matcher.group(1);
+            List<String> values = queryMap.get(varName);
+
+            if (values == null || values.isEmpty()) {
+                monitor.warning("Path parameter '%s' not found in query params for template '%s'"
+                        .formatted(varName, template));
+                continue;
+            }
+
+            resolvedPath = resolvedPath.replace("{" + varName + "}", values.get(0));
+            substitutedKeys.add(varName);
+        }
+
+        monitor.debug("Resolved path: %s".formatted(resolvedPath));
+        builder.path(resolvedPath);
+
+        substitutedKeys.forEach(queryMap::remove);
+        builder.queryParams(buildQueryString(queryMap));
+
+        return builder;
+    }
+
+    private Map<String, List<String>> parseQueryParams(String queryParams) {
+        Map<String, List<String>> queryMap = new HashMap<>();
+        if (queryParams == null || queryParams.isBlank()) {
+            return queryMap;
+        }
+        HttpUrl url = HttpUrl.parse("https://example.com?" + queryParams);
+        if (url == null) {
+            return queryMap;
+        }
+        for (int i = 0, size = url.querySize(); i < size; i++) {
+            queryMap.computeIfAbsent(url.queryParameterName(i), k -> new ArrayList<>())
+                    .add(url.queryParameterValue(i));
+        }
+        return queryMap;
+    }
+
+    private String buildQueryString(Map<String, List<String>> queryMap) {
+        if (queryMap.isEmpty()) {
+            return null;
+        }
+        HttpUrl.Builder urlBuilder = new HttpUrl.Builder().scheme("https").host("example.com");
+        queryMap.forEach((key, values) -> values.forEach(v -> urlBuilder.addQueryParameter(key, v)));
+        return urlBuilder.build().query();
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes a bug where EDC assets generated from OpenAPI endpoints with path
parameters (e.g. `GET /resources/{id}`) failed with HTTP 500 because the path
parameter value provided by the consumer was never forwarded to the backend.

There were two root causes in the OAS extension:

1. **Path template stored literally**: `createAssets()` was setting the raw OpenAPI
   template string (e.g. `/resources/{id}`) as the `path` property of the
   `dataAddress`, meaning the backend was called with the literal `{id}` in the URL.
2. **No substitution mechanism**: there was no component responsible for resolving
   path parameter values at request time.

### Solution: `PathTemplateHttpParamsDecorator`

A new `HttpParamsDecorator` is introduced. For assets backed by endpoints with path
parameters, `createAssets()` now stores the OpenAPI path template as a custom
`pathTemplate` property on the `dataAddress` (instead of using it as the literal
`path`). At request time, `PathTemplateHttpParamsDecorator` reads the template,
substitutes each `{variable}` with the matching consumer-provided query parameter,
and removes those keys from the forwarded query string so they do not reach the
backend.

This approach handles all path parameter positions correctly:
- Parameter at the end: `GET /resources/{id}` → consumer sends `?id=42`
- Parameter in the middle: `GET /resources/{id}/sub` → consumer sends `?id=42`
- Multiple parameters: `GET /{version}/resources/{id}` → consumer sends `?version=v2&id=42`
- Extra query parameters not related to path params are preserved and forwarded as-is

Assets without path parameters are completely unaffected: their `dataAddress` is
built identically to before, and the new decorator is a no-op for them.

### Also included

- `edc:openApiOperation` property added to DCAT assets, exposing the full OpenAPI
  operation object (parameters, schema, description) so consumers can discover the
  parameter names and types directly from the catalog.

## Changes

- **`PathTemplateHttpParamsDecorator.java`** (new): implements `HttpParamsDecorator`;
  reads `pathTemplate` from the data address, substitutes `{variables}` using
  consumer query params, and cleans them from the forwarded query string.
- **`OpenAPICoreExtension.java`**:
  - `createAssets()`: detects path parameters via `path.contains("{")` and stores
    the template as a `pathTemplate` property instead of the literal `path`.
  - `initialize()`: registers `PathTemplateHttpParamsDecorator` as a source decorator.
  - Adds `edc:openApiOperation` as an asset property with the serialized OpenAPI
    operation object.

## Test plan

- [ ] Manual end-to-end: consumer requests an asset with path parameters passing the
  values as query params → data plane resolves and forwards the correct URL → HTTP 200.
- [ ] Manual regression: consumer requests an asset without path parameters → still
  returns HTTP 200 with the expected response.